### PR TITLE
add noreferrer noopener to external link with target: _blank

### DIFF
--- a/content/projects.md
+++ b/content/projects.md
@@ -3,7 +3,7 @@ title: "Projects"
 draft: false
 ---
 
-<a href="https://jackiebinya.github.io/free-mentors-challenge-final/UI/" target="_blank" class="social-link">
+<a href="https://jackiebinya.github.io/free-mentors-challenge-final/UI/" target="_blank" rel="noopener noreferrer" class="social-link">
       <image src="https://res.cloudinary.com/di70zcupa/image/upload/v1588093965/Jacqueline%20Binya%20Website%20Assets/Free_Mentors_wwcsfx.png" width = "500px" height = "300px" alt="Image Preveiw of Freementors project"> 
 </a>
 <div class="project-desc">


### PR DESCRIPTION
this link was being flagged in lighthouse as insecure due to a lack of one
of the rel attribute. `noreferrer` adds support for older browsers that don't
support `noopener`.

![unsafe links](https://user-images.githubusercontent.com/5070516/85708359-fdc72000-b6db-11ea-8081-26ebd8e2c817.png)

The other link looks like it's coming from within the anubis theme layout, so I'll open a PR there directly.